### PR TITLE
Minor fix in do_get_s3_archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 dynamodump
 ==========
 
-[![Buildstatus](https://travis-ci.org/bchew/dynamodump.svg)](https://travis-ci.org/bchew/dynamodump) [![DockerBuildstatus](https://img.shields.io/docker/build/bchew/dynamodump.svg)](https://hub.docker.com/r/bchew/dynamodump/)
+[![Buildstatus](https://travis-ci.org/kyhau/dynamodump.svg)](https://travis-ci.org/kyhau/dynamodump) [![DockerBuildstatus](https://img.shields.io/docker/build/khau/dynamodump.svg)](https://hub.docker.com/r/khau/dynamodump/)
 
 Simple backup and restore script for Amazon DynamoDB using boto to work similarly to mysqldump.
 

--- a/dynamodump.py
+++ b/dynamodump.py
@@ -178,6 +178,7 @@ def do_get_s3_archive(profile, region, bucket, table, archive):
     try:
         contents = s3.list_objects_v2(
             Bucket=bucket,
+            Prefix=args.dumpPath
         )
     except botocore.exceptions.ClientError as e:
         logging.exception("Issue listing contents of bucket " + bucket + "\n\n" + str(e))
@@ -187,7 +188,7 @@ def do_get_s3_archive(profile, region, bucket, table, archive):
     # Therefore, just get item from bucket based on table name since that's what we name the files.
     filename = None
     for d in contents["Contents"]:
-        if d["Key"] == "dump/{}.{}".format(table, archive_type):
+        if d["Key"] == "{}/{}.{}".format(args.dumpPath, table, archive_type):
             filename = d["Key"]
 
     if not filename:


### PR DESCRIPTION
1. Added `Prefix` to the `s3.list_objects_v2` request to speed up the search.
1. Fixed a bug related to filename mapping during restore; should use `args.dumpPath` instead of`dump`.